### PR TITLE
chore: update automerge-action version in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Automerge
-        uses: 'pascalgn/automerge-action@v0.14.3'
+        uses: 'pascalgn/automerge-action@v0.15.6'
         env:
           GITHUB_TOKEN: '${{ secrets.RELEASE_TOKEN }}'
           MERGE_LABELS: ''


### PR DESCRIPTION
- Update the version of the `pascalgn/automerge-action` GitHub action from `v0.14.3` to `v0.15.6` in the `auto-merge.yml` workflow file.

Signed-off-by: DAST-Macbook <jackie@dast.tw>
