### PR TITLE
chore: add .gitignore file and exclude README.md from being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
+# 忽略檔案
+.wget-hsts
+.code-workspace
+.DS_Store
+.env
+.log
+.md
+
+# 忽略資料夾
+__pycache__/
+*/__pycache__/
 .vscode/
+
+# 不忽略 README.md 文件
+!README.md


### PR DESCRIPTION
- Ignore certain files and folders in git using `.gitignore`
- Ignore specific files like `.wget-hsts`, `.code-workspace`, `.DS_Store`, `.env`, `.log`, and `.md`
- Ignore specific folders like `__pycache__/` and `*/__pycache__/`
- Exclude the `.vscode/` folder from being ignored
- Include the `README.md` file in the repository

Signed-off-by: HomePC-DAST <jackie@dast.tw>
