### PR TITLE
### ci: 增加 Telegram 推送事件的通知

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -1,0 +1,24 @@
+name: Telegram Notification Push
+
+on:
+  push
+
+jobs:
+
+  bulid:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: send message on push
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.BOT_ID }}
+        token: ${{ secrets.BOT_TOKEN }}
+        # github.actor: 觸發 event 的使用者名稱
+        # github.sha: commit 的 hash 值
+        # github.event.commits[0].message: commit message
+        # github.repository: repository 的名稱
+        message: |
+          ${{ github.actor }} 提交內容: 
+          ${{ github.event.commits[0].message }}
+          Repository: ${{ github.repository }}


### PR DESCRIPTION
- 新增文件 `.github/workflows/bot.yml`，其中包含一个 Telegram 推送任务
- 任务名称：Build，运行在 ubuntu-latest 上
- 步骤：使用 `appleboy/telegram-action@master` 在推送时发送消息
- Telegram 消息内容包含提交信息

Signed-off-by: DAST-OfficePC <jackie@dast.tw>

###
