### PR TITLE
docs: 強調家族升級後持續使用 iPhone12

### DIFF
--- a/public/saying.txt
+++ b/public/saying.txt
@@ -76,7 +76,11 @@ hirakujira,女人女人，累人累人;
 hirakujira,三十歲前：守身如玉飢餓行銷
 三十歲後：如狼似虎大甩賣;
 
-cloverdefa,老娘買了iPhone15Plus;
+cloverdefa,老娘買了iPhone15Plus,
+老爸買了iPhone16Pro,
+老弟買了iPhone16ProMax,
+
+全家只剩下我還在用最老的iPhone12;
 
 cloverdefa,分體式柱狀排列鍵盤讚;
 


### PR DESCRIPTION
- 擴充關於 cloverdefa&#39;s 家族升級至更新款 iPhone 的說法，強調只有說話者仍在使用較舊的 iPhone12。

Signed-off-by: WSL <jackie@dast.tw>
