### PR TITLE
feat: 實作具有自動滾動訊息的動態聊天室介面

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,84 +1,109 @@
 <!DOCTYPE html>
 <html lang="zh-Hant">
-
   <head>
     <meta charset="utf-8" />
-    <title>┌(┌^o^)┐</title>
+    <title>聊天室樣式</title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bulma/0.8.2/css/bulma.min.css" />
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/css/all.min.css" />
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Rubik&display=swap" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/vue/2.6.11/vue.min.js"></script>
-    <script type="text/javascript">
-      // HTTP => HTTPS
-      if (location.protocol !== 'https:' && location.hostname !== 'localhost') {
-        location.protocol = 'https:'
-      }
-    </script>
     <style>
       html, body {
-        height: 100%; /* 讓頁面高度充滿視窗 */
-        margin: 0; /* 移除默認的外邊距 */
-        display: flex; /* 設定為flex布局 */
-        justify-content: center; /* 水平居中 */
-        align-items: center; /* 垂直居中 */
+        height: 100%;
+        margin: 0;
         background-color: #18232c;
+        font-family: 'Rubik', sans-serif;
       }
 
       [v-cloak] {
         display: none;
       }
 
-      .box {
-        background-color: #18232c; /* 設定與背景一致的顏色 */
-        color: white; /* 文字顏色設為白色以便可讀 */
-        padding: 24px; /* 增大內邊距 */
-        border-radius: 12px; /* 增大圓角 */
-        border: none; /* 確保無邊框 */
-        max-width: 840px; /* 增加最大寬度 */
-        width: 100%; /* 寬度 100% 使其可根據屏幕調整 */
-        font-size: 42px; /* 增加字型大小 */
+      .chat-container {
+        max-width: 640px;
+        margin: 0 auto;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow-y: auto;
       }
 
-      .content small {
-        color: gray;
+      .message-row {
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: 16px;
       }
 
-      #icon>img {
+      .media-left {
+        margin-right: 12px;
+      }
+
+      .message-bubble {
+        background-color: #2a3744;
+        color: white;
+        padding: 16px;
+        border-radius: 16px;
+        max-width: 100%;
+        word-wrap: break-word;
+        font-size: 18px;
+        line-height: 1.5;
+        position: relative;
+      }
+
+      .message-header {
+        font-weight: bold;
+        margin-bottom: 4px;
+      }
+
+      .message-meta {
+        font-size: 0.8rem;
+        color: #bbb;
+        margin-left: 8px;
+      }
+
+      .message-bubble pre {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      #icon img {
         border-radius: 50%;
       }
 
-      pre {
-        white-space: pre-wrap; /* 支援換行符 */
-        word-break: break-word; /* 長字元換行 */
-        margin: 0; /* 移除預設的外間距 */
+      figure.image.is-64x64 {
+        min-width: 64px;
+        min-height: 64px;
       }
     </style>
+    <script>
+      // 強制轉 HTTPS（非 localhost）
+      if (location.protocol !== 'https:' && location.hostname !== 'localhost') {
+        location.protocol = 'https:'
+      }
+    </script>
   </head>
 
   <body>
-    <div id="app" class="container">
-      <div class="box" v-cloak>
-        <article class="media">
-          <div class="media-left">
-            <figure class="image is-64x64" id="icon">
-              <img :src="avatar" alt="Image">
-              <span class="icon"></span>
-            </figure>
+    <div id="app" class="chat-container" v-cloak>
+      <div class="message-row"
+           v-for="(m, i) in messages"
+           :key="i">
+        <figure class="image is-64x64 media-left">
+          <img :src="m.avatar" alt="avatar">
+        </figure>
+        <div class="message-bubble">
+          <div class="message-header">
+            {{ m.name }}
+            <span class="message-meta">@{{ m.uname }} · {{ relativeTime(m.ts) }}</span>
           </div>
-          <div class="media-content">
-            <div class="content">
-              <p>
-                <strong>{{ name }}</strong> <small>@{{ uname }}</small> <small> · 1m</small>
-                <br>
-                <pre>{{ message }}</pre> <!-- 使用 pre 來支援多行顯示 -->
-              </p>
-            </div>
-          </div>
-        </article>
+          <pre>{{ m.text }}</pre>
+        </div>
       </div>
     </div>
+
     <script src="public/main.js"></script>
   </body>
-
 </html>
 

--- a/public/main.js
+++ b/public/main.js
@@ -1,38 +1,57 @@
 /* global Vue */
-(async () => {
+;(async () => {
+  // 使用者頭像/暱稱索引
   const gravatar = {
-    hirakujira: { name: 'DK', avatar: 'bf73e08d8bc1db95b62f02d50f8a03e9' },
-    cloverdefa: { name: 'DAST', avatar: '8cf3d8725d034584f237753022279119' },
-    bill85101: {name: '魔王', avatar: '9e202866b38b7255f282beb005576731' },
-    Shawn_N: {name: '賽瑞福', avatar: '34624582cd585ba65e5b5368c84cb1a2' }
+    hirakujira: { name: 'DK',      avatar: 'bf73e08d8bc1db95b62f02d50f8a03e9' },
+    cloverdefa: { name: 'DAST',    avatar: '8cf3d8725d034584f237753022279119' },
+    bill85101:   { name: '魔王',    avatar: '9e202866b38b7255f282beb005576731' },
+    Shawn_N:     { name: '賽瑞福',  avatar: '34624582cd585ba65e5b5368c84cb1a2' }
   }
-  const file = await fetch('public/saying.txt')
-  const text = await file.text()
-  const saying = text.split(';').slice(0, -1).map(x => x.trim())
-  new Vue({ // eslint-disable-line no-new
+
+  // 讀取 saying.txt；格式：username,內容;
+  const txt = await (await fetch('public/saying.txt')).text()
+  const sayings = txt.split(';').map(s => s.trim()).filter(Boolean)
+
+  new Vue({
     el: '#app',
     data: {
-      saying: saying,
-      uname: '',
-      name: '',
-      avatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000000',
-      message: ''
+      sayings,          // 原始句庫
+      messages: []      // 聊天訊息陣列
     },
     methods: {
-      updateSaying () {
-        const idx = Math.floor(Math.random() * this.saying.length)
-        const saying = this.saying[idx].split(',')
-        this.uname = saying[0]
-        this.name = gravatar[this.uname].name
-        this.avatar = `https://www.gravatar.com/avatar/${gravatar[this.uname].avatar}`
-        this.message = saying[1]
+      // 新增一則隨機訊息
+      addRandomMessage () {
+        const [uname, msg] = this.sayings[Math.floor(Math.random() * this.sayings.length)].split(',')
+        const info = gravatar[uname] || { name: uname, avatar: '00000000000000000000000000000000' }
+
+        this.messages.push({
+          uname,
+          name: info.name,
+          avatar: `https://www.gravatar.com/avatar/${info.avatar}`,
+          text:  msg.trim(),
+          ts:    Date.now()
+        })
+
+        // 只保留最近 30 則
+        if (this.messages.length > 30) this.messages.shift()
+
+        // 下一個 tick 後捲到底
+        this.$nextTick(() => {
+          const box = this.$el
+          box.scrollTop = box.scrollHeight
+        })
+      },
+      // 簡易「幾分鐘前」字串
+      relativeTime (t) {
+        const diff = Date.now() - t
+        return diff < 60_000 ? '剛剛' : Math.floor(diff / 60_000) + 'm'
       }
     },
     created () {
-      (function f () {
-        this.updateSaying()
-        return setTimeout(f.bind(this), 5000)
-      }).bind(this)()
+      // 立即顯示第一則，之後每 5 秒新增
+      this.addRandomMessage()
+      setInterval(this.addRandomMessage, 5000)
     }
   })
 })()
+


### PR DESCRIPTION
- 將頁面標題更改為「聊天室樣式」，並更新樣式以建立包含訊息氣泡、頭像及時間戳記的聊天介面。
- 以彈性且可滾動的聊天容器取代舊版佈局，訊息以橫列方式顯示，包含頭像及格式化文字。
- 將 HTTPS 重導向腳本移至樣式設定之後，確保除 localhost 外正確套用。
- 重構 JavaScript，從文字檔載入語錄，並將其顯示為帶有使用者資訊及頭像的聊天訊息。
- 實作每 5 秒新增隨機聊天訊息，僅保留最近 30 則訊息，並自動滾動聊天視窗。
- 新增輔助方法，將時間戳記格式化為相對時間字串，如「剛剛」或「幾分鐘前」。

Signed-off-by: WSL <jackie@dast.tw>
