### PR TITLE
重構：隱藏訊息元資料中的使用者名稱，僅顯示時間戳記

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
       <div class="message-bubble">
         <div class="message-header">
           {{ m.name }}
-          <span class="message-meta">@{{ m.uname }} · {{ relativeTime(m.ts) }}</span>
+          <span class="message-meta">{{ relativeTime(m.ts) }}</span>
         </div>
         <pre>{{ m.text }}</pre>
       </div>


### PR DESCRIPTION
- 移除訊息元資料中的使用者名稱顯示，改為僅顯示相對時間戳記。

Signed-off-by: Macbook Air <jackie@dast.tw>
